### PR TITLE
Fix FFmpeg example for PlainRtpTransport

### DIFF
--- a/documentation/v3/communication-between-client-and-server.md
+++ b/documentation/v3/communication-between-client-and-server.md
@@ -190,9 +190,9 @@ Let's assume we have a `/home/foo/party.mp4` file with a stereo audio track and 
 * Create a plain RTP transport in the mediasoup router to send the audio track:
 
 ```javascript
-const audioTransport = await router.createPlainTransport(
+const audioTransport = await router.createPlainRtpTransport(
   { 
-    ip       : '127.0.0.1',
+    listenIp : '127.0.0.1',
     rtcpMux  : false,
     comedia  : true
   });
@@ -209,9 +209,9 @@ const audioRtcpPort = audioTransport.rtcpTuple.localPort;
 * Create a plain RTP transport in the mediasoup router to send the video track:
 
 ```javascript
-const videoTransport = await router.createPlainTransport(
+const videoTransport = await router.createPlainRtpTransport(
   { 
-    ip       : '127.0.0.1',
+    listenIp : '127.0.0.1',
     rtcpMux  : false,
     comedia  : true
   });

--- a/documentation/v3/mediasoup/rtp-parameters-and-capabilities.md
+++ b/documentation/v3/mediasoup/rtp-parameters-and-capabilities.md
@@ -83,7 +83,7 @@ The RTP receive parameters describe a media stream as sent by mediasoup to an en
 * The `mid` value is unset (mediasoup does not include the MID RTP extension into RTP packets being sent to endpoints).
 * There is a single entry in the `encodings` array (even if the corresponding producer uses simulcast). The consumer sends a single and continuous RTP stream to the endpoint and spatial/temporal layer selection is possible via [consumer.setPreferredLayers()](/documentation/v3/mediasoup/api/#consumer-setPreferredLayers).
 * As an exception, previous bullet is not true when consuming a stream over a [PipeTransport](/documentation/v3/mediasoup/api/#PipeTransport), in which all RTP streams from the associated producer are forwarded verbatim through the consumer.
-* No matter the original RTP send parameters of the associated producer have `rid` in each entry in `encodings`, the RTP receive parameters will replace them with entries having a randomly generated `ssrc` value (and optional `rtx: { ssrc: XXXX }` if the endpoint supports RTX). 
+* The RTP receive parameters will always have their `ssrc` values randomly generated for all of its `encodings` (and optional `rtx: { ssrc: XXXX }` if the endpoint supports RTX), regardless of the original RTP send parameters in the associated producer. This applies even if the producer's `encodings` have `rid` set.
 
 #### RtpCapabilities
 {: #RtpCapabilities .code}


### PR DESCRIPTION
The source code in this example was using names that don't exist