### PR TITLE
fix: gn/ninja build error

### DIFF
--- a/documentation/v3/libmediasoupclient/installation.md
+++ b/documentation/v3/libmediasoupclient/installation.md
@@ -111,13 +111,13 @@ $ fetch --nohooks webrtc
 $ gclient sync
 $ cd src
 $ git checkout -b m74 refs/remotes/branch-heads/m74
+$ gclient sync
 ```
 
 * In OSX 10.14.16 this works:
 
 ```bash
-$ gn gen out/mybuild-m74 --args='is_debug=false is_component_build=false is_clang=true rtc_include_tests=false rtc_use_h264=true rtc_enable_protobuf=false use_rtti=true mac_deployment_target="10.14" use_custom_libcxx=false'
-$ ninja -C out/mybuild-m74
+$ gn gen out/mybuild-m74 --args='is_debug=false is_component_build=false is_clang=true rtc_include_tests=false rtc_use_h264=true rtc_enable_protobuf=false use_rtti=true mac_deployment_target="10.11" use_custom_libcxx=false'
 ```
 
 * In Linux Debian Stretch with GCC 6.3 this works:


### PR DESCRIPTION
It's recommended to run gclient sync after checking out the m74 branch, not doing so gave me an unidentified error.

Also using mac_deployment_target 10.14 gave a lot of deprecated errors when running ninja.
After changing this to 10.11 I was able to build with no issues.