### PR TITLE
Fix typo in docs regarding aiortc lib

### DIFF
--- a/documentation/v3/index.md
+++ b/documentation/v3/index.md
@@ -51,6 +51,6 @@ C++ library built on top of libwebrtc. It exposes the same API than mediasoup-cl
 ### mediasoup-client-aiortc
 {: .h3color}
 
-mediasoup-client handler for [aiortc](https://github.com/aiortc/aiortc/) Python library. Suitable for building Node.js applications that connect to a mediasoup server using WebRTC and exchange real audio, video and DataChannel messages with it in both directions.
+mediasoup-client handler for [aiortc](https://github.com/aiortc/aiortc/) Python library. Suitable for building Python applications that connect to a mediasoup server using WebRTC and exchange real audio, video and DataChannel messages with it in both directions.
 
 Documentation is exposed in the project [README](https://github.com/versatica/mediasoup-client-aiortc/blob/v3/README.md) file.

--- a/github.md
+++ b/github.md
@@ -23,7 +23,7 @@ C++ library based on libwebrtc.
 
 ##### [mediasoup-client-aiortc](https://github.com/versatica/mediasoup-client-aiortc/)
 
-handler for [aiortc](https://github.com/aiortc/aiortc/) Python library. Suitable for building Node.js applications that connect to a mediasoup server using WebRTC and exchange real audio, video and DataChannel messages with it.
+handler for [aiortc](https://github.com/aiortc/aiortc/) Python library. Suitable for building Python applications that connect to a mediasoup server using WebRTC and exchange real audio, video and DataChannel messages with it.
 
 
 ##### [mediasoup-demo](https://github.com/versatica/mediasoup-demo/)


### PR DESCRIPTION
In the descriptions of the aiortc project, it says "Node.js applications" instead of "python applications"