### PR TITLE
Add reference to RFC6464 to AudioLevelObserver

### DIFF
--- a/_includes/documentation/v3/mediasoup/api/AudioLevelObserver.md
+++ b/_includes/documentation/v3/mediasoup/api/AudioLevelObserver.md
@@ -7,6 +7,8 @@
 
 An audio level observer monitors the volume of the selected audio producers. It just handles audio producers (if [addProducer()](#rtpObserver-addProducer) is called with a video producer it will fail).
 
+Audio levels are read from an RTP header extension. No decoding of audio data is done. See [RFC6464](https://tools.ietf.org/html/rfc6464) for more information.
+
 </section>
 
 


### PR DESCRIPTION
I had a question about how AudioLevelObservers work, since I knew MediaSoup doesn't do any media decoding. I figured other people might have the same question, so I updated the docs. Hope this helps!