### PR TITLE
Basic mention of Rust crate

### DIFF
--- a/_compass/_home.scss
+++ b/_compass/_home.scss
@@ -186,6 +186,10 @@
 						@include user-select(none);
 					}
 				}
+
+				p {
+					text-align: center;
+				}
 			}
 		}
 	}

--- a/about.md
+++ b/about.md
@@ -47,6 +47,7 @@ I'm a core author of [JsSIP][jssip-url] "The JavaScript SIP library" and co-auth
 
 Special thanks for their contributions, help and advice to:
 
+* [Nazar Mokrynskyi][nazar-personal-url]: Rust version of mediasoup and various improvements.
 * [Saúl Ibarra Corretgé][saghul-personal-url]: Advice on libuv usage and GYP.
 * [Gustavo García][gustavo-personal-url]: The source of WebRTC knowledge.
 * [Haiyang Wu][haiyangwu-personal-url]: Windows support for mediasoup.
@@ -86,6 +87,7 @@ You can support mediasoup by [sponsoring](/sponsor/#become-a-sponsor) it. Thanks
 [ortc-draft-url]: https://draft.ortc.org
 [jssip-url]: https://jssip.net
 
+[nazar-personal-url]: https://github.com/nazar-pc
 [saghul-personal-url]: https://about.me/saghul
 [gustavo-personal-url]: https://www.rtcbits.com
 [haiyangwu-personal-url]: https://github.com/haiyangwu

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -11,7 +11,7 @@ A brief introduction to mediasoup and its ecosystem.
 
 ##### [v3 Documentation](/documentation/v3/)
 
-mediasoup, mediasoup-client and libmediasoupclient v3.
+mediasoup, mediasoup-rust, mediasoup-client and libmediasoupclient v3.
 
 ##### [v2 Documentation](/documentation/v2/)
 

--- a/documentation/v3/index.md
+++ b/documentation/v3/index.md
@@ -18,6 +18,14 @@ title : v3
 
 {% include documentation/v3/mediasoup/index.md %}
 
+### mediasoup-rust
+{: .h3color}
+
+Brings the same powerful C++ SFU to the Rust ecosystem, shares design philosophy with Node.js module.
+
+* [Documentation on docs.rs](https://docs.rs/mediasoup)
+* [Crate on crates.io](https://crates.io/crates/mediasoup)
+
 ### mediasoup-client
 {: .h3color}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ gulp.task('jekyll:build', shell.task(
 ));
 
 gulp.task('jekyll:watch', shell.task(
-	[ 'bundle exec jekyll serve --host 0.0.0.0' ]
+	[ 'bundle exec jekyll serve --host 0.0.0.0 -P 3001' ]
 ));
 
 gulp.task('shields', async () =>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@ home : true
 	<div class="content loading">
 		<div class="code-container">
 			<pre><code><span class="no-select">$ </span>npm install mediasoup</code></pre>
+			<p>or</p>
+			<pre><code><span class="no-select">$ </span>cargo add mediasoup</code></pre>
 		</div>
 	</div>
 </div>
@@ -42,9 +44,9 @@ home : true
 		</div>
 
 		<div class="box second loading">
-			<h3>Node.js module</h3>
+			<h3>Node.js module or Rust crate</h3>
 
-			<p>Instead of creating yet another opinionated server, mediasoup is a Node.js module which can be integrated into a larger application.</p>
+			<p>Instead of creating yet another opinionated server, mediasoup can be used as Node.js module or Rust crate which can be integrated into a larger application.</p>
 			<p>mediasoup provides a low level API that enables different use cases up to your application.</p>
 		</div>
 


### PR DESCRIPTION
Very basic information to complement https://github.com/versatica/mediasoup/pull/518

Canonical places for crates to store docs and browse libraries are docs.rs and crates.io, so for now at least there is no need to have dedicated pages for Rust version, it links back to existing TypeScript documentation where necessary.