### PR TITLE
Add missing stats

### DIFF
--- a/documentation/v3/mediasoup/rtc-statistics.md
+++ b/documentation/v3/mediasoup/rtc-statistics.md
@@ -29,6 +29,7 @@ const stats = await webRtcTransport.getStats();
 // =>
 [
   {
+    "availableOutgoingBitrate": 6750000,
     "bytesReceived": 5360091,
     "bytesSent": 20988,
     "dtlsState": "connected",
@@ -41,11 +42,13 @@ const stats = await webRtcTransport.getStats();
       "remotePort": 52320
     },
     "iceState": "completed",
+    "maxIncomingBitrate": 5500000,
     "probationBytesSent": 0,
     "probationSendBitrate": 0,
     "recvBitrate": 1802072,
     "rtpBytesReceived": 5104571,
     "rtpBytesSent": 0,
+    "rtpcPacketLossSent": 0,
     "rtpRecvBitrate": 1835651,
     "rtpSendBitrate": 0,
     "rtxBytesReceived": 179934,

--- a/documentation/v3/mediasoup/rtc-statistics.md
+++ b/documentation/v3/mediasoup/rtc-statistics.md
@@ -48,7 +48,7 @@ const stats = await webRtcTransport.getStats();
     "recvBitrate": 1802072,
     "rtpBytesReceived": 5104571,
     "rtpBytesSent": 0,
-    "rtpcPacketLossSent": 0,
+    "rtpPacketLossSent": 0,
     "rtpRecvBitrate": 1835651,
     "rtpSendBitrate": 0,
     "rtxBytesReceived": 179934,


### PR DESCRIPTION
This PR adds a few missing stats to the [WebRtcTransport Statistics](https://mediasoup.org/documentation/v3/mediasoup/rtc-statistics/#WebRtcTransport-Statistics) example.