### PR TITLE
comma add success

### DIFF
--- a/_includes/documentation/v3/mediasoup/api/Transport.md
+++ b/_includes/documentation/v3/mediasoup/api/Transport.md
@@ -346,7 +346,7 @@ const producer = await transport.produce(
       encodings :
       [
         { rid: "r0", active: true, maxBitrate: 100000 },
-        { rid: "r1", active: true, maxBitrate: 300000 }
+        { rid: "r1", active: true, maxBitrate: 300000 },
         { rid: "r2", active: true, maxBitrate: 900000 }
       ],
       rtcp :
@@ -731,4 +731,3 @@ transport.observer.on("newdataconsumer", (dataConsumer) =>
 Same as the [trace](#transport-on-trace) event.
 
 </section>
-


### PR DESCRIPTION
fixed: comma successfull add on page <a  href="https://mediasoup.org/documentation/v3/mediasoup/api/#Transport">https://mediasoup.org/documentation/v3/mediasoup/api/#Transport</a> , inside transport.produce<ProducerAppData>(options), in options for separate encodings options.