### PR TITLE
Document new changes/additions in mediasoup v3 done within flatbuffers branch

### DIFF
--- a/_includes/documentation/v3/mediasoup/api/DataConsumer.md
+++ b/_includes/documentation/v3/mediasoup/api/DataConsumer.md
@@ -346,12 +346,12 @@ See the [Observer API](#observer-api) section below.
 Emitted when the data consumer is closed for whatever reason.
 
 #### dataConsumer.observer.on("pause", fn())
-{: #dataConsumer-observer-on-dataproducerpause .code}
+{: #dataConsumer-observer-on-pause .code}
 
 Emitted when the data consumer is paused.
 
 #### dataConsumer.observer.on("resume", fn())
-{: #dataConsumer-observer-on-dataproducerresume .code}
+{: #dataConsumer-observer-on-resume .code}
 
 Emitted when the data consumer is resumed.
 

--- a/_includes/documentation/v3/mediasoup/api/DataConsumer.md
+++ b/_includes/documentation/v3/mediasoup/api/DataConsumer.md
@@ -25,8 +25,13 @@ Field            | Type    | Description   | Required | Default
 `maxPacketLifeTime` | Number | Just if consuming over SCTP. When `ordered` is `false`, it indicates the time (in milliseconds) after which a SCTP packet will stop being retransmitted. | No | The value in the data producer (if it's of type 'sctp') or unset (if it's of type 'direct').
 `maxRetransmits` | Number | Just if consuming over SCTP. When `ordered` is `false`, it indicates the maximum number of times a packet will be retransmitted. | No | The value in the data producer (if it's of type 'sctp') or unset (if it's of type 'direct').
 `paused`         | Boolean | Whether the data consumer must start in paused mode. | No | `false`
+`subchannels`    | Array&lt;Number&gt; | Subchannels (unsigned 16 bit integers) this data consumer initially subscribes to. | No |
 `appData`        | [AppData](#AppData) | Custom application data. | No | `{ }`
 
+</div>
+
+<div markdown="1" class="note">
+`subchannels` are only used in case this data consumer receives messages from a data producer created on a direct transport that specifies subchannel(s) when calling [dataProducer.send()](#dataProducer-send).
 </div>
 
 </section>
@@ -120,6 +125,17 @@ Whether the associated data producer is paused.
 
 > `@type` Boolean, read only
 
+#### dataConsumer.subchannels
+{: #dataConsumer-subchannels .code}
+
+Subchannels (unsigned 16 bit integers) this data consumer is currently subscribed to.
+
+> `@type` Array&lt;Number&gt;, read only
+
+<div markdown="1" class="note">
+`subchannels` are only used in case this data consumer receives messages from a data producer created on a direct transport that specifies subchannel(s) when calling [dataProducer.send()](#dataProducer-send).
+</div>
+
 #### dataConsumer.appData
 {: #dataConsumer-appData .code}
 
@@ -196,7 +212,8 @@ Whenever the underlaying SCTP association buffered bytes drop to this value, [bu
 Sends direct messages from the Node.js process.
 
 <div markdown="1" class="note">
-Just available in data consumers of type "SCTP".
+- Just available in data consumers of type "SCTP".
+- If the data cannot be sent due to the underlying SCTP send buffer being full, the method will fail with an Error instance which `message` equals `sctpsendbufferfull`.
 </div>
 
 <div markdown="1" class="table-wrapper L3">
@@ -216,10 +233,6 @@ dataConsumer.send(stringMessage);
 dataConsumer.send(binaryMessage);
 ```
 
-<div markdown="1" class="note">
-If the data cannot be sent due to the underlying SCTP send buffer being full, the method will fail with an Error instance which `message` equals `sctpsendbufferfull`.
-</div>
-
 > `@async`
 
 #### dataConsumer.pause()
@@ -235,6 +248,29 @@ Pauses the data consumer (no messages are sent to the consuming endpoint).
 Resumes the data consumer (messages are sent again to the consuming endpoint).
 
 > `@async`
+
+#### dataConsumer.setSubchannels(subchannels)
+{: #dataConsumer-setSubchannels .code}
+
+Update subchannels this data consumer is subscribed to.
+
+<div markdown="1" class="table-wrapper L3">
+
+Argument  | Type    | Description | Required | Default 
+--------- | ------- | ----------- | -------- | ----------
+`subchannels` | Array&lt;Number&gt; | Subchannels (unsigned 16 bit integers) this data consumer is subscribed to. | Yes |
+
+</div>
+
+> `@async`
+
+<div markdown="1" class="note">
+`subchannels` are only used in case this data consumer receives messages from a data producer created on a direct transport that specifies subchannel(s) when calling [dataProducer.send()](#dataProducer-send).
+</div>
+
+```javascript
+dataConsumer.setSubchannels([ 1, 4 ]);
+```
 
 </section>
 

--- a/_includes/documentation/v3/mediasoup/api/DataConsumer.md
+++ b/_includes/documentation/v3/mediasoup/api/DataConsumer.md
@@ -24,6 +24,7 @@ Field            | Type    | Description   | Required | Default
 `ordered`        | Boolean | Just if consuming over SCTP. Whether data messages must be received in order. If `true` the messages will be sent reliably. | No | The value in the data producer (if it's of type 'sctp') or `true` (if it's of type 'direct').
 `maxPacketLifeTime` | Number | Just if consuming over SCTP. When `ordered` is `false`, it indicates the time (in milliseconds) after which a SCTP packet will stop being retransmitted. | No | The value in the data producer (if it's of type 'sctp') or unset (if it's of type 'direct').
 `maxRetransmits` | Number | Just if consuming over SCTP. When `ordered` is `false`, it indicates the maximum number of times a packet will be retransmitted. | No | The value in the data producer (if it's of type 'sctp') or unset (if it's of type 'direct').
+`paused`         | Boolean | Whether the data consumer must start in paused mode. | No | `false`
 `appData`        | [AppData](#AppData) | Custom application data. | No | `{ }`
 
 </div>
@@ -104,6 +105,20 @@ The data consumer label.
 The data consumer sub-protocol.
 
 > `@type` String , read only
+
+#### dataConsumer.paused
+{: #dataConsumer-paused .code}
+
+Whether the data consumer is paused.
+
+> `@type` Boolean, read only
+
+#### dataConsumer.dataProducerPaused
+{: #dataConsumer-dataProducerPaused .code}
+
+Whether the associated data producer is paused.
+
+> `@type` Boolean, read only
 
 #### dataConsumer.appData
 {: #dataConsumer-appData .code}
@@ -207,6 +222,20 @@ If the data cannot be sent due to the underlying SCTP send buffer being full, th
 
 > `@async`
 
+#### dataConsumer.pause()
+{: #dataConsumer-pause .code}
+
+Pauses the data consumer (no messages are sent to the consuming endpoint).
+
+> `@async`
+
+#### dataConsumer.resume()
+{: #dataConsumer-resume .code}
+
+Resumes the data consumer (messages are sent again to the consuming endpoint).
+
+> `@async`
+
 </section>
 
 
@@ -238,6 +267,16 @@ dataConsumer.on("dataproducerclose", () =>
   console.log("associated data producer closed so dataConsumer closed");
 });
 ```
+
+#### dataConsumer.on("dataproducerpause", fn())
+{: #dataConsumer-on-dataproducerpause .code}
+
+Emitted when the associated data producer is paused.
+
+#### dataConsumer.on("dataproducerresume", fn())
+{: #dataConsumer-on-dataproducerresume .code}
+
+Emitted when the associated data producer is resumed.
 
 #### dataConsumer.on("message", fn(message, ppid))
 {: #dataConsumer-on-message .code}
@@ -305,5 +344,15 @@ See the [Observer API](#observer-api) section below.
 {: #dataConsumer-observer-on-close .code}
 
 Emitted when the data consumer is closed for whatever reason.
+
+#### dataConsumer.observer.on("pause", fn())
+{: #dataConsumer-observer-on-dataproducerpause .code}
+
+Emitted when the data consumer is paused.
+
+#### dataConsumer.observer.on("resume", fn())
+{: #dataConsumer-observer-on-dataproducerresume .code}
+
+Emitted when the data consumer is resumed.
 
 </section>

--- a/_includes/documentation/v3/mediasoup/api/DataProducer.md
+++ b/_includes/documentation/v3/mediasoup/api/DataProducer.md
@@ -145,14 +145,10 @@ Returns current statistics of the data producer.
 Check the [RTC Statistics](/documentation/v3/mediasoup/rtc-statistics/) section for more details.
 </div>
 
-#### dataProducer.send(message, ppid)
+#### dataProducer.send(message, ppid, subchannels, requiredSubchannel)
 {: #dataProducer-send .code}
 
 Sends direct messages from the Node.js process.
-
-<div markdown="1" class="note">
-Just available in direct transports, this is, those created via `router.createDirectTransport()`.
-</div>
 
 <div markdown="1" class="table-wrapper L3">
 
@@ -160,7 +156,13 @@ Argument  | Type    | Description | Required | Default
 --------- | ------- | ----------- | -------- | ----------
 `message` | String\|Buffer | Message to be sent (can be binary by using a Node.js Buffer). | Yes |
 `ppid`    | Number | Mimics the [SCTP Payload Protocol Identifier](https://www.iana.org/assignments/sctp-parameters/sctp-parameters.xhtml#sctp-parameters-25). In most cases it must not be set. | No | 51 (`WebRTC String`) if `message` is a String and 53 (`WebRTC Binary`) if it's a Buffer.
+`subchannels` | Array&lt;Number&gt; | Only data consumers subscribed to at least one of these subchannels (unsigned 16 bit integers) will receive the message. | No |
+`requiredSubchannel` | Number | Only data consumers subscribed to this subchannel (unsigned 16 bit integer) will receive the message. | No |
 
+</div>
+
+<div markdown="1" class="note">
+Just available in direct transports, this is, those created via `router.createDirectTransport()`.
 </div>
 
 ```javascript
@@ -169,6 +171,10 @@ const binaryMessage = Buffer.from([ 1, 2, 3, 4 ]);
 
 dataProducer.send(stringMessage);
 dataProducer.send(binaryMessage);
+```
+
+```javascript
+dataProducer.send("bye", /*ppid*/ undefined, /*subchannels*/ [ 24 ]);
 ```
 
 #### dataProducer.pause()

--- a/_includes/documentation/v3/mediasoup/api/DataProducer.md
+++ b/_includes/documentation/v3/mediasoup/api/DataProducer.md
@@ -23,6 +23,7 @@ Field                  | Type    | Description   | Required | Default
 `sctpStreamParameters` | [SctpStreamParameters](/documentation/v3/mediasoup/sctp-parameters/#SctpStreamParameters) | SCTP parameters defining how the endpoint is sending the data. Required if SCTP/DataChannel is used. Must not be given if the data producer is created on a `DirectTransport`. | No |
 `label`                | String | A label which can be used to distinguish this DataChannel from others. | No |
 `protocol`             | String | Name of the sub-protocol used by this DataChannel. | No |
+`paused`               | Boolean | Whether the data producer must start in paused mode. | No | `false`
 `appData`              | [AppData](#AppData) | Custom application data. | No | `{ }`
 
 </div>
@@ -97,6 +98,13 @@ The data producer sub-protocol.
 
 > `@type` String , read only
 
+#### dataProducer.paused
+{: #dataProducer-paused .code}
+
+Whether the data producer is paused.
+
+> `@type` Boolean, read only
+
 #### dataProducer.appData
 {: #dataProducer-appData .code}
 
@@ -163,6 +171,20 @@ dataProducer.send(stringMessage);
 dataProducer.send(binaryMessage);
 ```
 
+#### dataProducer.pause()
+{: #dataProducer-pause .code}
+
+Pauses the data producer (no messages are sent to its associated data consumers). Triggers a ["dataproducerpause"](#dataConsumer-on-dataproducerpause) event in all its associated data consumers.
+
+> `@async`
+
+#### dataProducer.resume()
+{: #dataProducer-resume .code}
+
+Resumes the data producer (messages are sent again to its associated data consumers). Triggers a ["dataproducerresume"](#dataConsumer-on-dataproducerresume) event in all its associated data consumers.
+
+> `@async`
+
 </section>
 
 
@@ -199,5 +221,15 @@ See the [Observer API](#observer-api) section below.
 {: #dataProducer-observer-on-close .code}
 
 Emitted when the producer is closed for whatever reason.
+
+#### dataProducer.observer.on("pause", fn())
+{: #dataProducer-observer-on-pause .code}
+
+Emitted when the data producer is paused.
+
+#### dataProducer.observer.on("resume", fn())
+{: #dataProducer-observer-on-resume .code}
+
+Emitted when the data producer is resumed.
 
 </section>

--- a/_includes/documentation/v3/mediasoup/api/PipeTransport.md
+++ b/_includes/documentation/v3/mediasoup/api/PipeTransport.md
@@ -26,6 +26,7 @@ When calling [consume()](#transport-consume) on a pipe transport, all RTP stream
 
 Field         | Type    | Description   | Required | Default
 ------------- | ------- | ------------- | -------- | ---------
+`listenInfo`  | [TransportListenInfo](#TransportListenInfo)| Listening information. | Yes |
 `listenIp`    | [TransportListenIp](#TransportListenIp)\|String| Listening IP address. | Yes |
 `port`        | Number  | Fixed port to listen on instead of selecting automatically from Worker's port range. | No |
 `enableSctp`  | Boolean | Create a SCTP association. | No | `false`
@@ -36,6 +37,10 @@ Field         | Type    | Description   | Required | Default
 `enableSrtp`  | Boolean | Enable SRTP to encrypt RTP and SRTP. If enabled, the paired `pipeTransport` must also enable this setting. | No | `false`
 `appData`     | [AppData](#AppData) | Custom application data. | No | `{ }`
 
+</div>
+
+<div markdown="1" class="note">
+* `listenIp` and `port` are **DEPRECATED**. Use `listenInfo` instead.
 </div>
 
 </section>

--- a/_includes/documentation/v3/mediasoup/api/PlainTransport.md
+++ b/_includes/documentation/v3/mediasoup/api/PlainTransport.md
@@ -22,6 +22,7 @@ A plain transport represents a network path through which RTP, RTCP (optionally 
 
 Field         | Type    | Description   | Required | Default
 ------------- | ------- | ------------- | -------- | ---------
+`listenInfo`  | [TransportListenInfo](#TransportListenInfo)| Listening information. | Yes |
 `listenIp`    | [TransportListenIp](#TransportListenIp)\|String| Listening IP address. | Yes |
 `port`        | Number  | Fixed port to listen on instead of selecting automatically from Worker's port range. | No |
 `rtcpMux`     | Boolean | Use RTCP-mux (RTP and RTCP in the same port). | No | `true`
@@ -37,6 +38,7 @@ Field         | Type    | Description   | Required | Default
 </div>
 
 <div markdown="1" class="note">
+* `listenIp` and `port` are **DEPRECATED**. Use `listenInfo` instead.
 * Note that `comedia` mode just makes sense when the remote endpoint is gonna produce RTP on this plain transport. Otherwise, if the remote endpoint does not send any RTP (or SCTP) packet to mediasoup, there is no way to detect its remote RTP IP and port, so the endpoint won't receive any packet from mediasoup.
 * In other words, do not use `comedia` mode if the remote endpoint is not going to produce RTP but just consume it. In those cases, do not set `comedia` flag and call [connect()](#plainTransport-connect) with the IP and port(s) of the remote endpoint. 
 </div>

--- a/_includes/documentation/v3/mediasoup/api/PlainTransport.md
+++ b/_includes/documentation/v3/mediasoup/api/PlainTransport.md
@@ -23,6 +23,7 @@ A plain transport represents a network path through which RTP, RTCP (optionally 
 Field         | Type    | Description   | Required | Default
 ------------- | ------- | ------------- | -------- | ---------
 `listenInfo`  | [TransportListenInfo](#TransportListenInfo)| Listening information. | Yes |
+`rtcpListenInfo` | [TransportListenInfo](#TransportListenInfo)| RTCP listening information. If not given and `rtcpPort` is not `false`, RTCP will use same listening info than RTP. | No |
 `listenIp`    | [TransportListenIp](#TransportListenIp)\|String| Listening IP address. | Yes |
 `port`        | Number  | Fixed port to listen on instead of selecting automatically from Worker's port range. | No |
 `rtcpMux`     | Boolean | Use RTCP-mux (RTP and RTCP in the same port). | No | `true`
@@ -39,6 +40,7 @@ Field         | Type    | Description   | Required | Default
 
 <div markdown="1" class="note">
 * `listenIp` and `port` are **DEPRECATED**. Use `listenInfo` instead.
+* `rtcpPort` is **DEPRECATED**. Use `rtcpListenInfo` instead to setup different listening information for RTCP.
 * Note that `comedia` mode just makes sense when the remote endpoint is gonna produce RTP on this plain transport. Otherwise, if the remote endpoint does not send any RTP (or SCTP) packet to mediasoup, there is no way to detect its remote RTP IP and port, so the endpoint won't receive any packet from mediasoup.
 * In other words, do not use `comedia` mode if the remote endpoint is not going to produce RTP but just consume it. In those cases, do not set `comedia` flag and call [connect()](#plainTransport-connect) with the IP and port(s) of the remote endpoint. 
 </div>

--- a/_includes/documentation/v3/mediasoup/api/Producer.md
+++ b/_includes/documentation/v3/mediasoup/api/Producer.md
@@ -222,14 +222,12 @@ Check the [RTC Statistics](/documentation/v3/mediasoup/rtc-statistics/) section 
 
 Pauses the producer (no RTP is sent to its associated consumers). Triggers a ["producerpause"](#consumer-on-producerpause) event in all its associated consumers.
 
-
 > `@async`
 
 #### producer.resume()
 {: #producer-resume .code}
 
 Resumes the producer (RTP is sent again to its associated consumers). Triggers a ["producerresume"](#consumer-on-producerresume) event in all its associated consumers.
-
 
 > `@async`
 

--- a/_includes/documentation/v3/mediasoup/api/Router.md
+++ b/_includes/documentation/v3/mediasoup/api/Router.md
@@ -44,6 +44,7 @@ Field         | Type               | Description   | Required | Default
 `producerId` | String  | Producer id. | No      |
 `dataProducerId` | String  | Data producer id. | No      |
 `router`     | [Router](#Router) | Destination router to pipe the given producer. | Yes |
+`listenInfo` | [TransportListenInfo](#TransportListenInfo)| Listening information to connect both routers in the same host. | No | `{ protocol: "udp", ip: "127.0.0.1" }`
 `listenIp`   | String  | IP to connect both routers in the same host. | No | "127.0.0.1"
 `enableSctp` | Boolean | Create a SCTP association. | No | `true`
 `numSctpStreams` | [NumSctpStreams](#NumSctpStreams) | SCTP streams number. | No |
@@ -53,6 +54,7 @@ Field         | Type               | Description   | Required | Default
 </div>
 
 <div markdown="1" class="note">
+* `listenIp` is **DEPRECATED**. Use `listenInfo` instead.
 * Only one of `producerId` and `dataProducerId` must be provided.
 * SCTP arguments will only apply the first time the underlying transports are created.
 </div>
@@ -167,12 +169,23 @@ TypeScript argument | Type    | Description | Required | Default
 ```javascript
 const transport = await router.createWebRtcTransport(
   {
-    // Use webRtcServer or listenIps
     webRtcServer : webRtcServer
-    listenIps    : [ { ip: "192.168.0.111", announcedIp: "88.12.10.41" } ],
     enableUdp    : true,
-    enableTcp    : true,
-    preferUdp    : true
+    enableTcp    : false
+  });
+```
+
+```javascript
+const transport = await router.createWebRtcTransport(
+  {
+    listenInfos :
+    [
+      {
+        protocol    : "udp", 
+        ip          : "192.168.0.111", 
+        announcedIp : "88.12.10.41"
+      }
+    ]
   });
 ```
 
@@ -205,9 +218,9 @@ TypeScript argument | Type    | Description | Required | Default
 ```javascript
 const transport = await router.createPlainTransport(
   {
-    listenIp : "a1:22:aA::08",
-    rtcpMux  : true,
-    comedia  : true
+    listenInfo : { protocol: "udp", ip: "a1:22:aA::08" },
+    rtcpMux    : true,
+    comedia    : true
   });
 ```
 
@@ -240,7 +253,7 @@ TypeScript argument | Type    | Description | Required | Default
 ```javascript
 const transport = await router.createPipeTransport(
   {
-    listenIp : "192.168.1.33"
+    listenInfo : { protocol: "udp", ip: "192.168.1.33" },
   });
 ```
 
@@ -274,7 +287,7 @@ TypeScript argument | Type    | Description | Required | Default
 const transport = await router.createDirectTransport();
 ```
 
-#### router.pipeToRouter({ producerId, dataProducerId, router, listenIp })
+#### router.pipeToRouter(options)
 {: #router-pipeToRouter .code}
 
 Pipes the given media or data producer into another router in the same host. It creates an underlying [PipeTransport](#PipeTransport) (if not previously created) that interconnects both routers.

--- a/_includes/documentation/v3/mediasoup/api/Transport.md
+++ b/_includes/documentation/v3/mediasoup/api/Transport.md
@@ -22,6 +22,28 @@ mediasoup implements the following transport classes:
 
 <section markdown="1">
 
+#### TransportListenInfo
+{: #TransportListenInfo .code}
+
+<div markdown="1" class="table-wrapper L3">
+
+Field         | Type    | Description   | Required | Default
+------------- | ------- | ------------- | -------- | ---------
+`protocol`    | String  | Protocol ("udp" / "tcp"). | Yes |
+`ip`          | String  | Listening IPv4 or IPv6. | Yes      |
+`announcedIp` | String  | Announced IPv4 or IPv6 (useful when running mediasoup behind NAT with private IP). | No      |
+`port`        | Number  | Listening port. | No | If not given, a random available port from the Worker's port range will be used.
+`sendBufferSize` | Number  | Send buffer size (in bytes). | No |
+`recvBufferSize` | Number  | Receive buffer size (in bytes). | No |
+
+</div>
+
+<div markdown="1" class="note">
+If you use "0.0.0.0" or "::" as `ip` value, then you need to also provide `announcedIp`.
+</div>
+
+<section markdown="1">
+
 #### TransportListenIp
 {: #TransportListenIp .code}
 
@@ -35,7 +57,8 @@ Field         | Type    | Description   | Required | Default
 </div>
 
 <div markdown="1" class="note">
-If you use "0.0.0.0" or "::" as `ip` value, then you need to also provide `announcedIp`.
+* **DEPRECATED:** Use [TransportListenInfo](#TransportListenInfo) instead.
+* If you use "0.0.0.0" or "::" as `ip` value, then you need to also provide `announcedIp`.
 </div>
 
 #### TransportTuple

--- a/_includes/documentation/v3/mediasoup/api/WebRtcServer.md
+++ b/_includes/documentation/v3/mediasoup/api/WebRtcServer.md
@@ -3,7 +3,7 @@
 
 <section markdown="1">
 
-A WebRTC server brings the ability to listen on a single UDP/TCP port to [WebRtcTransports](#WebRtcTransport). Instead of passing `listenIps` to [router.createWebRtcTransport()](#router-createWebRtcTransport) pass `webRtcServer` with an instance of a `WebRtcServer` so the new WebRTC transport will not listen on its own IP:port(s) but will have its network traffic handled by the WebRTC server instead.
+A WebRTC server brings the ability to listen on a single UDP/TCP port to [WebRtcTransports](#WebRtcTransport). Instead of passing `listenInfos` to [router.createWebRtcTransport()](#router-createWebRtcTransport) pass `webRtcServer` with an instance of a `WebRtcServer` so the new WebRTC transport will not listen on its own IP:port(s) but will have its network traffic handled by the WebRTC server instead.
 
 <div markdown="1" class="note">
 * A WebRTC server exists within the context of a [Worker](#Worker), meaning that if your app launches N workers it also needs to create N WebRTC servers listening on different ports (to not collide).
@@ -12,26 +12,6 @@ A WebRTC server brings the ability to listen on a single UDP/TCP port to [WebRtc
 
 </section>
 
-
-### Dictionaries
-{: #WebRtcServer-dictionaries}
-
-<section markdown="1">
-
-#### WebRtcServerListenInfo
-{: #WebRtcServerListenInfo .code}
-
-<div markdown="1" class="table-wrapper L3">
-
-Field         | Type    | Description   | Required | Default
-------------- | ------- | ------------- | -------- | ---------
-`protocol`    | String  | Protocol ("udp" / "tcp"). | Yes |
-`ip`          | String  | Listening IPv4 or IPv6. | Yes      |
-`announcedIp` | String  | Announced IPv4 or IPv6 (useful when running mediasoup behind NAT with private IP). | No      |
-`port`        | Number  | Listening port. | No | If not given, a random available port from the Worker's port range will be used.
-
-</div>
-
 #### WebRtcServerOptions
 {: #WebRtcServerOptions .code}
 
@@ -39,7 +19,7 @@ Field         | Type    | Description   | Required | Default
 
 Field        | Type    | Description   | Required | Default
 ------------ | ------- | ------------- | -------- | ---------
-`listenInfos`  | Array&lt;[WebRtcServerListenInfo](#WebRtcServerListenInfo)&gt; | Listening protocol, IP and port objects in order of preference (first one is the preferred one). | Yes |
+`listenInfos` | Array&lt;[TransportListenInfo](#TransportListenInfo)\|String&gt; | Listening information in order of preference (first one is the preferred one). | No |
 `appData`    | [AppData](#AppData) | Custom application data. | No | `{ }`
 
 </div>

--- a/_includes/documentation/v3/mediasoup/api/WebRtcTransport.md
+++ b/_includes/documentation/v3/mediasoup/api/WebRtcTransport.md
@@ -27,6 +27,7 @@ The WebRTC transport implementation of mediasoup is [ICE Lite](https://tools.iet
 Field        | Type    | Description   | Required | Default
 ------------ | ------- | ------------- | -------- | ---------
 `webRtcServer` | [WebRtcServer](#WebRtcServer) | Instead of opening its own listening port(s) let a WebRTC server handle the network traffic of this transport. | No |
+`listenInfos` | Array&lt;[TransportListenInfo](#TransportListenInfo)\|String&gt; | Listening information in order of preference (first one is the preferred one). | No |
 `listenIps`  | Array&lt;[TransportListenIp](#TransportListenIp)\|String&gt; | Listening IP address or addresses in order of preference (first one is the preferred one). | No |
 `port`       | Number  | Fixed port to listen on instead of selecting automatically from Worker's port range. | No |
 `enableUdp`  | Boolean | Listen in UDP. | No | `true`
@@ -43,10 +44,12 @@ Field        | Type    | Description   | Required | Default
 </div>
 
 <div markdown="1" class="note">
-* One of `webRtcServer` or `listenIps` must be given when creating a WebRTC transport.
-* The IP in each entry in `listenIps` must be a bindable IP in the host.
-* If you use "0.0.0.0" or "::" in an entry in `listenIps`, then you need to also provide `announcedIp` in the corresponding entry in `listenIps`.
+* `listenIps` is **DEPRECATED**. Use `listenInfos` instead.
+* One of `webRtcServer` or `listenInfos` or `listenIps` must be given when creating a WebRTC transport.
+* The IP in each entry in `listenInfos` or `listenIps` must be a bindable IP in the host.
+* If you use "0.0.0.0" or "::" in an entry in `listenInfos` or `listenIps`, then you need to also provide `announcedIp` in the corresponding entry.
 * `initialAvailableOutgoingBitrate` is just applied when the consumer endpoint supports REMB or Transport-CC.
+* `enableUdp`, `enableTcp`, `preferUdp` and `preferTcp` are only processed if `webRtcServer` is given, and they filter and define the priority of the ICE candidates available in the `webRtcServer`.
 </div>
 
 

--- a/documentation/v3/mediasoup/rtp-parameters-and-capabilities.md
+++ b/documentation/v3/mediasoup/rtp-parameters-and-capabilities.md
@@ -54,7 +54,7 @@ Field              | Type    | Description   | Required | Default
 `mid`              | String  | The MID RTP extension value as defined in the [BUNDLE](https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation) specification. | No |
 `codecs`           | Array&lt;[RtpCodecParameters](#RtpCodecParameters)&gt; | Media and RTX codecs in use. | Yes |
 `headerExtensions` | Array&lt;[RtpHeaderExtensionParameters](#RtpHeaderExtensionParameters)&gt; | RTP header extensions in use. | No | `[ ]`
-`encodings`        | Array&lt;[RtpEncodingParameters](#RtpEncodingParameters)&gt; | Transmitted RTP streams and their settings. | Yes |
+`encodings`        | Array&lt;[RtpEncodingParameters](#RtpEncodingParameters)&gt; | Transmitted RTP streams and their settings. | No |
 `rtcp`             | [RtcpParameters](#RtcpParameters) | Parameters used for RTCP. | No |
 
 </div>
@@ -70,6 +70,7 @@ The RTP send parameters describe a media stream received by mediasoup from an en
 * These parameters may include a `mid` value that the mediasoup transport will use to match received RTP packets based on their MID RTP extension value.
 * mediasoup allows RTP send parameters with a single encoding and with multiple encodings (simulcast). In the latter case, each entry in the `encodings` array must include a `ssrc` field or a `rid` field (the RID RTP extension value).
 * If a single encoding is given, RTP send parameters must include `mid` value or the encoding must indicate the `ssrc` of the stream.
+* If no encoding is given (so this is a simple stream without layers), then RTP send parameters must include `mid` value.
 
 <div markdown="1" class="note">
 Check the [Simulcast](#Simulcast) and [SVC](#SVC) sections for more information.


### PR DESCRIPTION
- [x] Document new `TransportListenInfo` in the website (PR https://github.com/versatica/mediasoup/pull/1084).
- [x] Document new `rtcpListenInfo` in `PlainTransportOptions` once PR https://github.com/versatica/mediasoup/pull/1099 is merged here.
- [x] Document the new pause/resume feature in `DataProducer` and `DataConsumer` (PR https://github.com/versatica/mediasoup/pull/1104):
  - `pause()`and `resume()` in `DataProducer` and `DataConsumer`.
  - `paused` getter in `DataProducer` and `DataConsumer`.
  - `dataproducerpause` and `dataproducerresume` events in `DataConsumer`.
  - `pause` and `resume` events in `DataProducer.observer` and `DataConsumer.observer`.
  - `paused?: boolean` in `transport.consumeData()` and `transport.produceData()`.
- [x] Document the new subchannels stuff (PR https://github.com/versatica/mediasoup/pull/1152).