### PR TITLE
Fix TransportListenInfo table

### DIFF
--- a/_includes/documentation/v3/mediasoup/api/Transport.md
+++ b/_includes/documentation/v3/mediasoup/api/Transport.md
@@ -33,12 +33,8 @@ Field         | Type    | Description   | Required | Default
 `ip`          | String  | Listening IPv4 or IPv6. | Yes |
 `announcedAddress` | String  | Announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT with private IP). | No |
 `port`        | Number  | Listening port. | No | If not given, a random available port from the Worker's port range will be used.
-<<<<<<< HEAD
-`flags`       | [TransportSocketFlags](#TransportSocketFlags) | UDP/TCP socket flags. | No | All flags are disabled.
-=======
 `portRange`   | [TransportPortRange](#TransportPortRange)  | Listening port range. | No | If given, a random available port in this range (in given IP and protocol) will be used.
 `flags`       | [TransportSocketFlags](#TransportSocketFlags) | UDP/TCP socket flags. | No | All flags are disabled.
->>>>>>> 26c2959 (Document new portRange field)
 `sendBufferSize` | Number  | Send buffer size (in bytes). | No |
 `recvBufferSize` | Number  | Receive buffer size (in bytes). | No |
 


### PR DESCRIPTION
Git artifacts break page rendering at https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo
This PR fixes this issue.